### PR TITLE
Iterative get_atoms

### DIFF
--- a/oo_scoping/tests/test_utils.py
+++ b/oo_scoping/tests/test_utils.py
@@ -5,6 +5,7 @@ import z3
 
 from oo_scoping.utils import get_atoms
 
+
 class TestGetAtomsBase(unittest.TestCase):
     def test_get_atoms(self):
         A = z3.Bool("A")
@@ -21,14 +22,11 @@ class TestGetAtomsBase(unittest.TestCase):
         D = z3.Int("D")
         cd = z3.Not(C == D)
 
-        expr = z3.Or(z3.And(A,B), cd)
-        atoms = {A,B,C,D}
+        expr = z3.Or(z3.And(A, B), cd)
+        atoms = {A, B, C, D}
         atoms_pred = set(get_atoms(expr))
         self.assertEqual(atoms_pred, atoms, str(atoms_pred))
 
 
-
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/oo_scoping/utils.py
+++ b/oo_scoping/utils.py
@@ -265,31 +265,26 @@ def get_atoms(
     Returns list of base-level z3 expressions from list of (potentially) high level z3 expressions.
     Ex. 'a == b' would be returned as [a,b], where a and b are baselevel z3 expressions (intref, boolref, etc)
     """
-    # TODO remove duplicates
-    atoms = []
+    atoms = set()
     open_nodes = list(args)
-    closed_nodes = []
     while len(open_nodes) > 0:
         expr = open_nodes.pop()
-        closed_nodes.append(expr)
         # We don't need to add python primitives as atoms
         if isinstance(expr, (bool, int)):
             continue
         if isinstance(expr, z3.Goal):  # What is a z3.Goal ?
             expr = expr.as_expr()
-            # IDK if we need this
-            closed_nodes.append(expr)
         
         children = expr.children()
         if len(children) == 0:
-            atoms.append(expr)
+            atoms.add(expr)
         else:
             open_nodes.extend(children)
 
     if remove_constants:
         atoms = remove_constant_atoms(atoms)
 
-    return atoms
+    return list(atoms)
 
 
 def remove_constant_atoms(atoms):


### PR DESCRIPTION
Made get_atoms iterative rather than recursive.

Added an extra test for get_atoms and moved the tests to test_utils.py

The tests pass with the old and new version of get_atoms.

The tests are not exhaustive.